### PR TITLE
Automatically pickup items when cutting down trees (1.21.0)

### DIFF
--- a/Common/src/main/java/com/natamus/treeharvester/config/ConfigHandler.java
+++ b/Common/src/main/java/com/natamus/treeharvester/config/ConfigHandler.java
@@ -26,6 +26,7 @@ public class ConfigHandler extends DuskConfig {
 	@Entry public static boolean increaseHarvestingTimePerLog = true;
 	@Entry(min = 0.01, max = 10.0) public static double increasedHarvestingTimePerLogModifier = 0.2;
 	@Entry(min = 1, max = 16) public static int amountOfLeavesBrokenPerTick = 5;
+	public static boolean automaticallyPickupItems = true;
 
 	public static void initConfig() {
 		configMetaData.put("mustHoldAxeForTreeHarvest", Arrays.asList(
@@ -75,6 +76,9 @@ public class ConfigHandler extends DuskConfig {
 		));
 		configMetaData.put("amountOfLeavesBrokenPerTick", Arrays.asList(
 			"How many leaves should be broken per tick after a tree has been harvested. Increasing this will speed up the fast leaf decay, but costs more processing power per tick."
+		));
+		configMetaData.put("automaticallyPickupItems", Arrays.asList(
+			"If enabled, automatically picks up items that are dropped when a tree is harvested including the leaf drops."
 		));
 
 		DuskConfig.init(Reference.NAME, Reference.MOD_ID, ConfigHandler.class);

--- a/Common/src/main/java/com/natamus/treeharvester/config/ConfigHandler.java
+++ b/Common/src/main/java/com/natamus/treeharvester/config/ConfigHandler.java
@@ -26,7 +26,7 @@ public class ConfigHandler extends DuskConfig {
 	@Entry public static boolean increaseHarvestingTimePerLog = true;
 	@Entry(min = 0.01, max = 10.0) public static double increasedHarvestingTimePerLogModifier = 0.2;
 	@Entry(min = 1, max = 16) public static int amountOfLeavesBrokenPerTick = 5;
-	public static boolean automaticallyPickupItems = true;
+	public static boolean automaticallyPickupItems = false;
 
 	public static void initConfig() {
 		configMetaData.put("mustHoldAxeForTreeHarvest", Arrays.asList(

--- a/Common/src/main/java/com/natamus/treeharvester/data/Variables.java
+++ b/Common/src/main/java/com/natamus/treeharvester/data/Variables.java
@@ -21,7 +21,7 @@ public class Variables {
 	public static HashMap<BlockPos, Integer> highestleaf = new HashMap<BlockPos, Integer>();
 	public static CopyOnWriteArrayList<Triplet<Date, BlockPos, CopyOnWriteArrayList<BlockPos>>> saplingPositions = new CopyOnWriteArrayList<Triplet<Date, BlockPos, CopyOnWriteArrayList<BlockPos>>>();
 
-	public static final HashMap<Level, CopyOnWriteArrayList<BlockPos>> processTickLeaves = new HashMap<Level, CopyOnWriteArrayList<BlockPos>>();
-	public static final HashMap<Level, CopyOnWriteArrayList<BlockPos>> processBreakLeaves = new HashMap<Level, CopyOnWriteArrayList<BlockPos>>();
-	public static final HashMap<Pair<Level, Player>, Pair<Date, Integer>> harvestSpeedCache = new HashMap<Pair<Level, Player>, Pair<Date, Integer>>();
+	public static final HashMap<Level, CopyOnWriteArrayList<BlockPos>> processTickLeaves = new HashMap<>();
+	public static final HashMap<Level, CopyOnWriteArrayList<Pair<BlockPos, Player>>> processBreakLeaves = new HashMap<>();
+	public static final HashMap<Pair<Level, Player>, Pair<Date, Integer>> harvestSpeedCache = new HashMap<>();
 }

--- a/Common/src/main/java/com/natamus/treeharvester/events/SaplingEvents.java
+++ b/Common/src/main/java/com/natamus/treeharvester/events/SaplingEvents.java
@@ -1,8 +1,6 @@
 package com.natamus.treeharvester.events;
 
-import com.natamus.collective.functions.BlockPosFunctions;
 import com.natamus.treeharvester.config.ConfigHandler;
-import com.natamus.treeharvester.data.Variables;
 import com.natamus.treeharvester.util.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
@@ -12,10 +10,8 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import oshi.util.tuples.Triplet;
 
-import java.util.Date;
-import java.util.concurrent.CopyOnWriteArrayList;
+import static com.natamus.treeharvester.processing.SaplingProcessing.placeSaplings;
 
 public class SaplingEvents {
 	public static void onSaplingItem(Level level, Entity entity) {
@@ -46,31 +42,6 @@ public class SaplingEvents {
 		BlockPos itemPos = itemEntity.blockPosition();
 		BlockPos yZeroItemPos = itemPos.atY(0);
 
-		Date now = new Date();
-		for (Triplet<Date, BlockPos, CopyOnWriteArrayList<BlockPos>> triplet : Variables.saplingPositions) {
-			long ms = (now.getTime()-triplet.getA().getTime());
-			if (ms > 2000) {
-				Variables.saplingPositions.remove(triplet);
-				continue;
-			}
-
-			if (BlockPosFunctions.withinDistance(yZeroItemPos, triplet.getB().atY(0), 6)) {
-				for (BlockPos lowerLog : triplet.getC()) {
-					if (itemStack.getCount() > 0) {
-						level.setBlock(lowerLog, block.defaultBlockState(), 3);
-						itemStack.shrink(1);
-						triplet.getC().remove(lowerLog);
-					}
-				}
-
-				if (triplet.getC().size() == 0) {
-					Variables.saplingPositions.remove(triplet);
-				}
-			}
-
-			if (itemStack.getCount() == 0) {
-				return;
-			}
-		}
+		placeSaplings(level, yZeroItemPos, itemStack, block);
 	}
 }

--- a/Common/src/main/java/com/natamus/treeharvester/processing/LeafProcessing.java
+++ b/Common/src/main/java/com/natamus/treeharvester/processing/LeafProcessing.java
@@ -1,9 +1,11 @@
 package com.natamus.treeharvester.processing;
 
+import com.mojang.datafixers.util.Pair;
 import com.natamus.collective.functions.BlockPosFunctions;
 import com.natamus.treeharvester.data.Variables;
 import com.natamus.treeharvester.util.Util;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 
@@ -13,7 +15,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class LeafProcessing {
-    public static void breakTreeLeaves(Level level, List<BlockPos> logsToBreak, BlockPos lowestCenterLogPos, BlockPos highestLogPos) {
+    public static void breakTreeLeaves(Level level, Player player, List<BlockPos> logsToBreak, BlockPos lowestCenterLogPos, BlockPos highestLogPos) {
         if (level.isClientSide) {
             return;
         }
@@ -40,7 +42,7 @@ public class LeafProcessing {
         }
 
         if (!Variables.processBreakLeaves.containsKey(level)) {
-            Variables.processBreakLeaves.put(level, new CopyOnWriteArrayList<BlockPos>());
+            Variables.processBreakLeaves.put(level, new CopyOnWriteArrayList<>());
         }
 
         BlockPos highestLeafPos = highestLogPos.above().immutable();
@@ -89,8 +91,8 @@ public class LeafProcessing {
                 }
             }
 
-            if (!Variables.processBreakLeaves.get(level).contains(treeBlockPos)) {
-                Variables.processBreakLeaves.get(level).add(treeBlockPos);
+            if (!Variables.processBreakLeaves.get(level).contains(new Pair<>(treeBlockPos, player))) {
+                Variables.processBreakLeaves.get(level).add(new Pair<>(treeBlockPos, player));
             }
         }
     }

--- a/Common/src/main/java/com/natamus/treeharvester/processing/SaplingProcessing.java
+++ b/Common/src/main/java/com/natamus/treeharvester/processing/SaplingProcessing.java
@@ -1,0 +1,68 @@
+package com.natamus.treeharvester.processing;
+
+import com.natamus.collective.functions.BlockPosFunctions;
+import com.natamus.treeharvester.config.ConfigHandler;
+import com.natamus.treeharvester.data.Variables;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import oshi.util.tuples.Triplet;
+
+import java.util.Date;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class SaplingProcessing {
+    public static void onSaplingItem(Level level, Player player, ItemStack itemStack, BlockPos leafPos) {
+        if (level.isClientSide) {
+            return;
+        }
+
+        if (!ConfigHandler.replaceSaplingOnTreeHarvest || !ConfigHandler.automaticallyPickupItems) {
+            return;
+        }
+
+        Block block = Block.byItem(itemStack.getItem());
+        BlockPos yZeroPlayerPos = player.getOnPos().atY(0);
+//        BlockPos yZeroItemPos = leafPos.atY(0);
+
+        placeSaplings(level, yZeroPlayerPos, itemStack, block);
+//        placeSaplings(level, yZeroItemPos, itemStack, block);
+
+        if (itemStack.getCount() > 0) {
+            if(!player.addItem(itemStack)) {
+                Block.popResource(level, leafPos, itemStack);
+            }
+        }
+    }
+
+    public static void placeSaplings(Level level, BlockPos yZeroItemPos, ItemStack itemStack, Block block) {
+        Date now = new Date();
+        for (Triplet<Date, BlockPos, CopyOnWriteArrayList<BlockPos>> triplet : Variables.saplingPositions) {
+            long ms = (now.getTime()-triplet.getA().getTime());
+            if (ms > 2000) {
+                Variables.saplingPositions.remove(triplet);
+                continue;
+            }
+
+            if (BlockPosFunctions.withinDistance(yZeroItemPos, triplet.getB().atY(0), 6)) {
+                for (BlockPos lowerLog : triplet.getC()) {
+                    if (itemStack.getCount() > 0) {
+                        level.setBlock(lowerLog, block.defaultBlockState(), 3);
+                        itemStack.shrink(1);
+                        triplet.getC().remove(lowerLog);
+                    }
+                }
+
+                if (triplet.getC().size() == 0) {
+                    Variables.saplingPositions.remove(triplet);
+                }
+            }
+
+            if (itemStack.getCount() == 0) {
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I only tested on Fabric 1.21.0

When cutting down a tree this will pick up all items, If there's no place for the items it will mimck vanilla behaviour of dropping the items where the block was destoryed.

Closes Serilum/.issue-tracker#1998